### PR TITLE
feat(pathfinding): export strategies

### DIFF
--- a/src/GridEngine.ts
+++ b/src/GridEngine.ts
@@ -27,7 +27,7 @@ import { NoPathFoundStrategy } from "./Pathfinding/NoPathFoundStrategy";
 import { PathBlockedStrategy } from "./Pathfinding/PathBlockedStrategy";
 import { Concrete } from "./Utils/TypeUtils";
 
-export { Direction };
+export { PathBlockedStrategy, NoPathFoundStrategy, Direction };
 
 export type TileSizePerSecond = number;
 


### PR DESCRIPTION
both the `PathBlockedStrategy` and `NoPathFoundStrategy` haven't been exported and this would help reduce typo's through more type-safety