### PR TITLE
fix(esm): re-export in esm build

### DIFF
--- a/src/main-esm.ts
+++ b/src/main-esm.ts
@@ -1,4 +1,14 @@
-import { GridEngine, Direction } from "./GridEngine";
+import { GridEngine } from "./GridEngine";
+export {
+    GridEngine,
+    Direction,
+    NoPathFoundStrategy,
+    CollisionStrategy,
+    Finished, FrameRow,
+    MoveToConfig,
+    MoveToResult,
+    NumberOfDirections,
+    PathBlockedStrategy
+} from "./GridEngine";
 
-export { GridEngine, Direction };
 export default GridEngine;


### PR DESCRIPTION
Hey there @Annoraaq

I'm sorry but I've just now realized that the previous PR wasn't fully addressing the export of additional PathStrategies. I didn't see the way how you're constructing your ESM bundle so I thought while at it also export the other string enums.

I've just realized this once trying out the build with vite as bundler which is taking the esm dependency as preferred solution.