### PR TITLE
Add method to find characters based on position and layer

### DIFF
--- a/src/GridEngine.test.ts
+++ b/src/GridEngine.test.ts
@@ -45,6 +45,7 @@ const mockFollowMovement = {
 const mockGridTileMap = {
   addCharacter: jest.fn(),
   removeCharacter: jest.fn(),
+  getCharactersAt: jest.fn(),
   getTileWidth: () => 32,
   getTileHeight: () => 32,
   getTransition: jest.fn(),
@@ -1069,6 +1070,25 @@ describe("GridEngine", () => {
     const chars = gridEngine.getAllCharacters();
     expect(chars).toEqual(["player", "player2"]);
   });
+
+  it("should delegate to get all chars at position", () => {
+    mockGridTileMap.getCharactersAt = jest.fn(() => new Set([
+      { getId: () => "player" }
+    ]));
+
+    gridEngine.create(tileMapMock, {
+      characters: [{
+        id: "player",
+        sprite: playerSpriteMock,
+      }]
+    });
+    const chars = gridEngine.getCharactersAt(new Vector2(5, 4), "layer");
+    expect(mockGridTileMap.getCharactersAt).toHaveBeenCalledWith(
+      { x: 5, y: 4 },
+      "layer"
+    );
+    expect(chars).toEqual(["player"]);
+  })
 
   it("should check if char is registered", () => {
     gridEngine.addCharacter({

--- a/src/GridEngine.ts
+++ b/src/GridEngine.ts
@@ -704,6 +704,16 @@ export class GridEngine {
   }
 
   /**
+   * Finds the identifiers of all characters at the provided tile position.
+   * @returns The identifiers of all characters on this tile.
+   */
+  getCharactersAt(position: Position, layer: string): string[] {
+    this.initGuard();
+    const characters = this.gridTilemap.getCharactersAt(new Vector2(position), layer);
+    return Array.from(characters).map(char => char.getId());
+  }
+
+  /**
    * Places the character with the given id to the provided tile position. If
    * that character is moving, the movement is stopped. The
    * {@link positionChanged} and {@link positionChangeFinished} observables will

--- a/src/GridTilemap/CharBlockCache/CharBlockCache.test.ts
+++ b/src/GridTilemap/CharBlockCache/CharBlockCache.test.ts
@@ -260,6 +260,37 @@ describe("CharBlockCache", () => {
     expect(hasBlockingCharOnOldPos).toBe(true);
   });
 
+  it("should find all characters", () => {
+    const charMock1 = <any>{
+      ...createCharMock("charMock1"),
+      getTilePos: () => ({ position: { x: 0, y: 1 }, layer: "someLayer" }),
+    };
+    const charMock2 = <any>{
+      ...createCharMock("charMock2"),
+      getTilePos: () => ({ position: { x: 0, y: 1 }, layer: "someLayer" }),
+    };
+    const charMockDifferentLayer = <any>{
+      ...createCharMock("charMockDifferentLayer"),
+      getTilePos: () => ({ position: { x: 0, y: 1 }, layer: "otherLayer" }),
+    };
+    
+    charBlockCache.addCharacter(charMock1);
+    charBlockCache.addCharacter(charMock2);
+    charBlockCache.addCharacter(charMockDifferentLayer);
+    expect(
+      charBlockCache.getCharactersAt(new Vector2(0, 1), "someLayer")
+    ).toContain(charMock1);
+    expect(
+      charBlockCache.getCharactersAt(new Vector2(0, 1), "someLayer")
+    ).toContain(charMock2);
+    expect(
+      charBlockCache.getCharactersAt(new Vector2(0, 1), "otherLayer")
+    ).toContain(charMockDifferentLayer);
+    expect(
+      charBlockCache.getCharactersAt(new Vector2(1, 1), "someLayer").size
+    ).toBe(0);
+  });
+
   it("should remove a character", () => {
     const positionChangeStartedSub = { unsubscribe: jest.fn() };
     const positionChangeStarted = {

--- a/src/GridTilemap/CharBlockCache/CharBlockCache.ts
+++ b/src/GridTilemap/CharBlockCache/CharBlockCache.ts
@@ -28,6 +28,15 @@ export class CharBlockCache {
     );
   }
 
+  getCharactersAt(
+    pos: Vector2,
+    layer: string
+  ): Set<GridCharacter> {
+    const posStr = this.posToString(pos, layer);
+    const characters = this.tilePosToCharacters.get(posStr);
+    return new Set(characters);
+  }
+
   addCharacter(character: GridCharacter): void {
     this.add(
       this.posToString(

--- a/src/GridTilemap/GridTilemap.test.ts
+++ b/src/GridTilemap/GridTilemap.test.ts
@@ -12,6 +12,7 @@ const mockCharBlockCache = {
   addCharacter: jest.fn(),
   removeCharacter: jest.fn(),
   isCharBlockingAt: jest.fn(),
+  getCharactersAt: jest.fn(),
 };
 
 const mockCharLayers = [
@@ -374,6 +375,21 @@ describe("GridTilemap", () => {
 
     expect(gridTilemap.getCharacters()).toEqual([charMock2]);
     expect(mockCharBlockCache.removeCharacter).toHaveBeenCalledWith(charMock1);
+  });
+
+  it("should find characters", () => {
+    gridTilemap = new GridTilemap(tilemapMock);
+
+    const charMocks = new Set<GridCharacter>();
+    charMocks.add(createCharMock("player"));
+    mockCharBlockCache.getCharactersAt = jest.fn(() => charMocks);
+
+    const set = gridTilemap.getCharactersAt(new Vector2(1, 1), "layer1");
+    expect(mockCharBlockCache.getCharactersAt).toHaveBeenCalledWith(
+      { x: 1, y: 1 },
+      "layer1"
+    );
+    expect(set).toBe(charMocks);
   });
 
   it("should detect blocking tiles", () => {

--- a/src/GridTilemap/GridTilemap.ts
+++ b/src/GridTilemap/GridTilemap.ts
@@ -42,6 +42,10 @@ export class GridTilemap {
     return [...this.characters.values()];
   }
 
+  getCharactersAt(position: Vector2, layer: string): Set<GridCharacter> {
+    return this.charBlockCache.getCharactersAt(position, layer);
+  }
+
   isBlocking(
     charLayer: string | undefined,
     pos: Vector2,


### PR DESCRIPTION
I needed a method to lookup all characters at a particular tile location without maintaining my own index of `{x,y} => [characterId]`

After browsing the repository I noticed that this index already existed in the `CharBlockCache.tilePosToCharacters` so thought it would be great to expose it to users, thereby allowing them to efficiently look up characters at a particular position.

I would have really liked to make the public API take an optional string for the layer, where if it was undefined it would look at all layers at that position - but it would have been more work than just getting what I needed right now 😄 

This code will hopefully replace this horrible mess in my code:

```typescript
const charId = this.gridEngine.getAllCharacters().map(id => {
  return {
    id: id, pos: this.gridEngine.getPosition(id)
  }
}).find(x => x.pos.x === position.x && x.pos.y === position.y)?.id;
```

with

```typescript
const charId = this.gridEngine.getCharactersAt(position, "charLevel1")[0];
```